### PR TITLE
feat/API: 중기 API, Swiper적용, 어제와 오늘 온도를 오늘과 내일로 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dayjs": "^1.11.8"
+        "dayjs": "^1.11.8",
+        "swiper": "^9.3.2"
       },
       "devDependencies": {
         "chart.js": "^4.3.0",
+        "css-loader": "^6.8.1",
+        "mini-css-extract-plugin": "^2.7.6",
+        "style-loader": "^3.3.3",
         "ts-loader": "^9.4.3",
         "typescript": "^5.0.4",
         "webpack": "^5.84.0",
@@ -1016,6 +1020,44 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-loader": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz",
+      "integrity": "sha512-xDAXtEVGlD0gJ07iclwWVkLoZOpEvAWaSyf6W18S2pOC//K8+qUDIx8IIT3D+HjnmkJPQeesOPv5aiUaJsCM2g==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.21",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.3",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.8",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
@@ -1702,6 +1744,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -2068,6 +2122,78 @@
         "node": ">=6"
       }
     },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
+      "dev": true,
+      "dependencies": {
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
+      "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -2103,6 +2229,24 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/negotiator": {
@@ -2359,6 +2503,112 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
+      "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -2851,6 +3101,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -2937,6 +3196,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2964,6 +3228,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/style-loader": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
+      "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2989,6 +3269,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.3.2.tgz",
+      "integrity": "sha512-Kj9Z4kXRmJR3YT/Wj+XLWj8P6IcRt+WG38uL8M3/Wny7+6sV0TlP9vnE1X+Co9c7VzNooojWGnFa+Wf/9+CUMA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "dependencies": {
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "license": "ISC",
   "devDependencies": {
     "chart.js": "^4.3.0",
+    "css-loader": "^6.8.1",
+    "mini-css-extract-plugin": "^2.7.6",
+    "style-loader": "^3.3.3",
     "ts-loader": "^9.4.3",
     "typescript": "^5.0.4",
     "webpack": "^5.84.0",
@@ -19,6 +22,7 @@
     "webpack-dev-server": "^4.15.0"
   },
   "dependencies": {
-    "dayjs": "^1.11.8"
+    "dayjs": "^1.11.8",
+    "swiper": "^9.3.2"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -15,31 +15,43 @@
     <script src="../dist/bundle.js" defer></script>
   </head>
   <body>
-    <div class="head_container">
-      <header class="header_title">
-        <h1 class="header_h1">
-          Yesterday & Today<br />
-          Temperature
-          <img
-            src="../assets/fever_temperature.png"
-            class="header_temperature_icon"
-            alt="header_temperature_icon"
-          />
-        </h1>
-      </header>
-      <nav class="nav">
-        <button class="nav_btn">
-          Go to Weekly
-          <img
-            src="../assets/fever_temperature.png"
-            class="btn_temperature_icon"
-            alt="btn_temperature_icon"
-          />
-        </button>
-      </nav>
+    <div class="swiper">
+      <div class="swiper-wrapper">
+        <div class="swiper-slide">
+          <div class="head_container">
+            <header class="header_title">
+              <h1 class="header_h1">
+                Today & Tomorrow<br />
+                Temperature
+                <img
+                  src="../assets/fever_temperature.png"
+                  class="header_temperature_icon"
+                  alt="header_temperature_icon"
+                />
+              </h1>
+            </header>
+          </div>
+          <canvas class="todayChart"></canvas>
+        </div>
+        <div class="swiper-slide">
+          <div class="head_container">
+            <header class="header_title">
+              <h1 class="header_h1">
+                Weekly<br />
+                Temperature
+                <img
+                  src="../assets/fever_temperature.png"
+                  class="header_temperature_icon"
+                  alt="header_temperature_icon"
+                />
+              </h1>
+            </header>
+          </div>
+          <canvas class="weeklyChart"></canvas>
+        </div>
+      </div>
+      <div class="swiper-button-prev"></div>
+      <div class="swiper-button-next"></div>
     </div>
-    <main>
-      <canvas class="myChart"></canvas>
-    </main>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,61 +1,104 @@
 /*
-TODO: 그래프 숫자범위 고정?
 FIXME: 차트 반응형?
 FIXME: 웹팩 HMR 안됨
-FIXME: 차트에 날짜 포맷 ex)6/6
-FIXME: await때문에 데이터를 다 받아오는데 까지 시간이 걸림 fetch분리?
 */
 
+import Swiper, { Navigation } from "swiper";
 import chartjs from "chart.js/auto";
 import dayjs from "dayjs";
 
+const swiper = new Swiper(".swiper", {
+  modules: [Navigation],
+  direction: "vertical",
+  loop: true,
+  navigation: {
+    nextEl: ".swiper-button-next",
+    prevEl: ".swiper-button-prev",
+  },
+  observer: true,
+  observeParents: true,
+  parallax: true,
+});
+
 //날짜 포맷
 const now = dayjs();
+//기상청 API 호출용 날짜 포맷
 const nowFormat = now.format("YYYYMMDD");
-const yesterday = now.subtract(1, "d").format("YYYYMMDD");
+//chart로 그릴 날짜 포맷
+const nowFormat2 = now.format("MM/DD");
+const tomorrow = now.add(1, "d").format("MM/DD");
+const dayAfterTomorrow = now.add(2, "d").format("MM/DD");
+const twoDaysAfterTomorrow = now.add(3, "d").format("MM/DD");
+const threeDaysAfterTomorrow = now.add(4, "d").format("MM/DD");
+const fourDaysAfterTomorrow = now.add(5, "d").format("MM/DD");
+const fiveDaysAfterTomorrow = now.add(6, "d").format("MM/DD");
+const sixDaysAfterTomorrow = now.add(7, "d").format("MM/DD");
 
-//API로 가져올 날짜
+//API로 조회할 날짜
 let dateArr: string[] = [];
-dateArr.push(yesterday);
-dateArr.push(nowFormat);
+dateArr.push(nowFormat2);
+dateArr.push(tomorrow);
+dateArr.push(dayAfterTomorrow);
+dateArr.push(twoDaysAfterTomorrow);
+dateArr.push(threeDaysAfterTomorrow);
+dateArr.push(fourDaysAfterTomorrow);
+dateArr.push(fiveDaysAfterTomorrow);
+dateArr.push(sixDaysAfterTomorrow);
 
 //TMN 일 최저기온
-let TMNArr: string[] = [];
+let TMNArr: string[] | number[] = [];
 //TMX 일 최고기온
-let TMXArr: string[] = [];
+let TMXArr: string[] | number[] = [];
 
-const getData = async () => {
+//오늘 & 내일 온도 그래프
+const getTodayData = async () => {
   try {
-    const resNow = await fetch("https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=F1%2FDTeneAsxTz0l63eAO7XlVSvkovHvIthVJX9h5P%2BiSWNp5k4gt9LAAif6c0tkk7u8ERcKROU%2BkgK5tJ20EwA%3D%3D&pageNo=1&numOfRows=1000&dataType=JSON&base_date=" + nowFormat + "&base_time=0500&nx=55&ny=127");
-    const resYesterday = await fetch("https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=F1%2FDTeneAsxTz0l63eAO7XlVSvkovHvIthVJX9h5P%2BiSWNp5k4gt9LAAif6c0tkk7u8ERcKROU%2BkgK5tJ20EwA%3D%3D&pageNo=1&numOfRows=1000&dataType=JSON&base_date=" + yesterday + "&base_time=0500&nx=55&ny=127");
+    const resNow = await fetch(
+      "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=F1%2FDTeneAsxTz0l63eAO7XlVSvkovHvIthVJX9h5P%2BiSWNp5k4gt9LAAif6c0tkk7u8ERcKROU%2BkgK5tJ20EwA%3D%3D&pageNo=1&numOfRows=1000&dataType=JSON&base_date=" +
+      nowFormat +
+      "&base_time=0200&nx=55&ny=127"
+    );
+
     let nowData = await resNow.json();
-    let YesterdayData = await resYesterday.json();
 
     const data = {
       //category : TMN 일 최저기온, item[301]
       //category : TMX 일 최고기온, item[410]
-      nowCategory1: nowData.response.body.items.item[301].category,
-      nowTMN: nowData.response.body.items.item[301].fcstValue,
-      nowCategory2: nowData.response.body.items.item[410].category,
-      nowTMX: nowData.response.body.items.item[410].fcstValue,
+      nowfcstDate1: nowData.response.body.items.item[48].fcstDate,
+      nowCategory1: nowData.response.body.items.item[48].category,
+      nowTMN: nowData.response.body.items.item[48].fcstValue,
+      nowfcstDate2: nowData.response.body.items.item[157].fcstDate,
+      nowCategory2: nowData.response.body.items.item[157].category,
+      nowTMX: nowData.response.body.items.item[157].fcstValue,
 
-      yesterdayCategory1: YesterdayData.response.body.items.item[301].category,
-      yesterdayTMN: YesterdayData.response.body.items.item[301].fcstValue,
-      yesterdayCategory2: YesterdayData.response.body.items.item[410].category,
-      yesterdayTMX: YesterdayData.response.body.items.item[410].fcstValue
-    }
+      tomorrowfcstDate1: nowData.response.body.items.item[338].fcstDate,
+      tomorrowCategory1: nowData.response.body.items.item[338].category,
+      tomorrowTMN: nowData.response.body.items.item[338].fcstValue,
+      tomorrowfcstDate2: nowData.response.body.items.item[447].fcstDate,
+      tomorrowCategory2: nowData.response.body.items.item[447].category,
+      tomorrowTMX: nowData.response.body.items.item[447].fcstValue,
 
-    TMNArr.push(data.nowTMN);
-    TMNArr.push(data.yesterdayTMN);
-    TMXArr.push(data.nowTMX);
-    TMXArr.push(data.yesterdayTMX);
+      dayAfterTomorrowfcstDate1: nowData.response.body.items.item[628].fcstDate,
+      dayAfterTomorrowCategory1: nowData.response.body.items.item[628].category,
+      dayAfterTomorrowTMN: nowData.response.body.items.item[628].fcstValue,
+      dayAfterTomorrowfcstDate2: nowData.response.body.items.item[737].fcstDate,
+      dayAfterTomorrowCategory2: nowData.response.body.items.item[737].category,
+      dayAfterTomorrowTMX: nowData.response.body.items.item[737].fcstValue,
+    };
 
-    const canvas = <HTMLCanvasElement>document.querySelector(".myChart");
+    TMNArr[0] = parseInt(data.nowTMN);
+    TMNArr[1] = parseInt(data.tomorrowTMN);
+    TMNArr[2] = parseInt(data.dayAfterTomorrowTMN);
+    TMXArr[0] = parseInt(data.nowTMX);
+    TMXArr[1] = parseInt(data.tomorrowTMX);
+    TMXArr[2] = parseInt(data.dayAfterTomorrowTMX);
+
+    const canvas = <HTMLCanvasElement>document.querySelector(".todayChart");
     const ctx = canvas.getContext("2d");
-    const myChart = new chartjs(ctx, {
+    const todayChart = new chartjs(ctx, {
       type: "line",
       data: {
-        labels: dateArr,
+        labels: [dateArr[0], dateArr[1]],
         datasets: [
           {
             label: "Lowest Temperature",
@@ -78,12 +121,72 @@ const getData = async () => {
     });
 
     chartjs.defaults.font.size = 15;
+  } catch (error) {
+    console.log("Error:", error);
+  }
 
+  getWeeklyData();
+
+};
+
+getTodayData();
+
+//주간 온도 그래프
+const getWeeklyData = async () => {
+  try {
+    const resWeekly = await fetch(
+      "https://apis.data.go.kr/1360000/MidFcstInfoService/getMidTa?serviceKey=F1%2FDTeneAsxTz0l63eAO7XlVSvkovHvIthVJX9h5P%2BiSWNp5k4gt9LAAif6c0tkk7u8ERcKROU%2BkgK5tJ20EwA%3D%3D&pageNo=1&numOfRows=10&dataType=JSON&regId=11B10101&tmFc=" + nowFormat + "0600"
+      );
+    
+    let weeklyData = await resWeekly.json();
+
+    const data = {
+      after3daysTMN: weeklyData.response.body.items.item[0].taMin3,
+      after3daysTMX: weeklyData.response.body.items.item[0].taMax3,
+
+      after4daysTMN: weeklyData.response.body.items.item[0].taMin4,
+      after4daysTMX: weeklyData.response.body.items.item[0].taMax4,
+
+      after5daysTMN: weeklyData.response.body.items.item[0].taMin5,
+      after5daysTMX: weeklyData.response.body.items.item[0].taMax5,
+    };
+
+    TMNArr[3] = data.after3daysTMN;
+    TMNArr[4] = data.after4daysTMN;
+    TMNArr[5] = data.after5daysTMN;
+    TMXArr[3] = data.after3daysTMX;
+    TMXArr[4] = data.after4daysTMX;
+    TMXArr[5] = data.after5daysTMX;
+
+    chartjs.defaults.font.size = 15;
+
+    const canvas = <HTMLCanvasElement>document.querySelector(".weeklyChart");
+    const ctx = canvas.getContext("2d");
+    const weeklyChart = new chartjs(ctx, {
+      type: "line",
+      data: {
+        labels: [dateArr[0], dateArr[1], dateArr[2],dateArr[3], dateArr[4], dateArr[5]],
+        datasets: [
+          {
+            label: "Lowest Temperature",
+            fill: false,
+            data: [TMNArr[0], TMNArr[1], TMNArr[2], TMNArr[3], TMNArr[4], TMNArr[5]],
+            backgroundColor: ["rgba(77,201,246, 0.2)"],
+            borderColor: ["rgba(77,201,246, 1)"],
+            borderWidth: 3,
+          },
+          {
+            label: "Highest Temperature",
+            fill: false,
+            data: [TMXArr[0],TMXArr[1],TMXArr[2],TMXArr[3],TMXArr[4], TMXArr[5]],
+            backgroundColor: ["rgba(255, 99, 132, 0.2)"],
+            borderColor: ["rgba(255, 99, 132, 1)"],
+            borderWidth: 3,
+          },
+        ],
+      },
+    });
   } catch (error) {
     console.log("Error:", error);
   }
 };
-
-getData();
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,25 +64,13 @@ const getTodayData = async () => {
     const data = {
       //category : TMN 일 최저기온, item[301]
       //category : TMX 일 최고기온, item[410]
-      nowfcstDate1: nowData.response.body.items.item[48].fcstDate,
-      nowCategory1: nowData.response.body.items.item[48].category,
       nowTMN: nowData.response.body.items.item[48].fcstValue,
-      nowfcstDate2: nowData.response.body.items.item[157].fcstDate,
-      nowCategory2: nowData.response.body.items.item[157].category,
       nowTMX: nowData.response.body.items.item[157].fcstValue,
 
-      tomorrowfcstDate1: nowData.response.body.items.item[338].fcstDate,
-      tomorrowCategory1: nowData.response.body.items.item[338].category,
       tomorrowTMN: nowData.response.body.items.item[338].fcstValue,
-      tomorrowfcstDate2: nowData.response.body.items.item[447].fcstDate,
-      tomorrowCategory2: nowData.response.body.items.item[447].category,
       tomorrowTMX: nowData.response.body.items.item[447].fcstValue,
 
-      dayAfterTomorrowfcstDate1: nowData.response.body.items.item[628].fcstDate,
-      dayAfterTomorrowCategory1: nowData.response.body.items.item[628].category,
       dayAfterTomorrowTMN: nowData.response.body.items.item[628].fcstValue,
-      dayAfterTomorrowfcstDate2: nowData.response.body.items.item[737].fcstDate,
-      dayAfterTomorrowCategory2: nowData.response.body.items.item[737].category,
       dayAfterTomorrowTMX: nowData.response.body.items.item[737].fcstValue,
     };
 
@@ -121,6 +109,7 @@ const getTodayData = async () => {
     });
 
     chartjs.defaults.font.size = 15;
+
   } catch (error) {
     console.log("Error:", error);
   }
@@ -158,8 +147,6 @@ const getWeeklyData = async () => {
     TMXArr[4] = data.after4daysTMX;
     TMXArr[5] = data.after5daysTMX;
 
-    chartjs.defaults.font.size = 15;
-
     const canvas = <HTMLCanvasElement>document.querySelector(".weeklyChart");
     const ctx = canvas.getContext("2d");
     const weeklyChart = new chartjs(ctx, {
@@ -186,6 +173,9 @@ const getWeeklyData = async () => {
         ],
       },
     });
+
+    chartjs.defaults.font.size = 15;
+
   } catch (error) {
     console.log("Error:", error);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,23 +27,23 @@ const nowFormat = now.format("YYYYMMDD");
 //chart로 그릴 날짜 포맷
 const nowFormat2 = now.format("MM/DD");
 const tomorrow = now.add(1, "d").format("MM/DD");
-const dayAfterTomorrow = now.add(2, "d").format("MM/DD");
-const twoDaysAfterTomorrow = now.add(3, "d").format("MM/DD");
-const threeDaysAfterTomorrow = now.add(4, "d").format("MM/DD");
-const fourDaysAfterTomorrow = now.add(5, "d").format("MM/DD");
-const fiveDaysAfterTomorrow = now.add(6, "d").format("MM/DD");
-const sixDaysAfterTomorrow = now.add(7, "d").format("MM/DD");
+const after2days = now.add(2, "d").format("MM/DD");
+const after3days = now.add(3, "d").format("MM/DD");
+const after4days = now.add(4, "d").format("MM/DD");
+const after5days = now.add(5, "d").format("MM/DD");
+const after6days = now.add(6, "d").format("MM/DD");
+const after7days = now.add(7, "d").format("MM/DD");
 
 //API로 조회할 날짜
 let dateArr: string[] = [];
 dateArr.push(nowFormat2);
 dateArr.push(tomorrow);
-dateArr.push(dayAfterTomorrow);
-dateArr.push(twoDaysAfterTomorrow);
-dateArr.push(threeDaysAfterTomorrow);
-dateArr.push(fourDaysAfterTomorrow);
-dateArr.push(fiveDaysAfterTomorrow);
-dateArr.push(sixDaysAfterTomorrow);
+dateArr.push(after2days);
+dateArr.push(after3days);
+dateArr.push(after4days);
+dateArr.push(after5days);
+dateArr.push(after6days);
+dateArr.push(after7days);
 
 //TMN 일 최저기온
 let TMNArr: string[] | number[] = [];
@@ -70,16 +70,16 @@ const getTodayData = async () => {
       tomorrowTMN: nowData.response.body.items.item[338].fcstValue,
       tomorrowTMX: nowData.response.body.items.item[447].fcstValue,
 
-      dayAfterTomorrowTMN: nowData.response.body.items.item[628].fcstValue,
-      dayAfterTomorrowTMX: nowData.response.body.items.item[737].fcstValue,
+      after2daysTMN: nowData.response.body.items.item[628].fcstValue,
+      after2daysTMX: nowData.response.body.items.item[737].fcstValue,
     };
 
     TMNArr[0] = parseInt(data.nowTMN);
     TMNArr[1] = parseInt(data.tomorrowTMN);
-    TMNArr[2] = parseInt(data.dayAfterTomorrowTMN);
+    TMNArr[2] = parseInt(data.after2daysTMN);
     TMXArr[0] = parseInt(data.nowTMX);
     TMXArr[1] = parseInt(data.tomorrowTMX);
-    TMXArr[2] = parseInt(data.dayAfterTomorrowTMX);
+    TMXArr[2] = parseInt(data.after2daysTMX);
 
     const canvas = <HTMLCanvasElement>document.querySelector(".todayChart");
     const ctx = canvas.getContext("2d");
@@ -138,26 +138,37 @@ const getWeeklyData = async () => {
 
       after5daysTMN: weeklyData.response.body.items.item[0].taMin5,
       after5daysTMX: weeklyData.response.body.items.item[0].taMax5,
+
+      after6daysTMN: weeklyData.response.body.items.item[0].taMin6,
+      after6daysTMX: weeklyData.response.body.items.item[0].taMax6,
+      
+      after7daysTMN: weeklyData.response.body.items.item[0].taMin7,
+      after7daysTMX: weeklyData.response.body.items.item[0].taMax7,
     };
 
     TMNArr[3] = data.after3daysTMN;
     TMNArr[4] = data.after4daysTMN;
     TMNArr[5] = data.after5daysTMN;
+    TMNArr[6] = data.after6daysTMN;
+    TMNArr[7] = data.after7daysTMN;
+
     TMXArr[3] = data.after3daysTMX;
     TMXArr[4] = data.after4daysTMX;
     TMXArr[5] = data.after5daysTMX;
+    TMXArr[6] = data.after6daysTMX;
+    TMXArr[7] = data.after7daysTMX;
 
     const canvas = <HTMLCanvasElement>document.querySelector(".weeklyChart");
     const ctx = canvas.getContext("2d");
     const weeklyChart = new chartjs(ctx, {
       type: "line",
       data: {
-        labels: [dateArr[0], dateArr[1], dateArr[2],dateArr[3], dateArr[4], dateArr[5]],
+        labels: dateArr,
         datasets: [
           {
             label: "Lowest Temperature",
             fill: false,
-            data: [TMNArr[0], TMNArr[1], TMNArr[2], TMNArr[3], TMNArr[4], TMNArr[5]],
+            data: TMNArr,
             backgroundColor: ["rgba(77,201,246, 0.2)"],
             borderColor: ["rgba(77,201,246, 1)"],
             borderWidth: 3,
@@ -165,7 +176,7 @@ const getWeeklyData = async () => {
           {
             label: "Highest Temperature",
             fill: false,
-            data: [TMXArr[0],TMXArr[1],TMXArr[2],TMXArr[3],TMXArr[4], TMXArr[5]],
+            data: TMXArr,
             backgroundColor: ["rgba(255, 99, 132, 0.2)"],
             borderColor: ["rgba(255, 99, 132, 1)"],
             borderWidth: 3,

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,5 @@
 @import "reset.css";
+@import "../node_modules/swiper/swiper-bundle.css";
 
 .head_container {
   display: flex;
@@ -8,7 +9,7 @@
 
 .header_title {
   width: 1200px;
-  margin: 50px 0 25px 130px;
+  margin: 50px 0 70px 130px;
 }
 
 .header_h1 {
@@ -20,30 +21,31 @@
   width: 52px;
 }
 
-.nav {
-  width: 400px;
-  margin: 100px 0 0 100px;
-}
-
-.nav_btn {
-  border-radius: 5px;
-  text-align: center;
-  background-color: rgb(94, 94, 94);
-  color: #ffffff;
-  font-weight: 600;
-  font-size: 17px;
-  border: none;
-  width: 170px;
-  height: 40px;
-  padding-left: 15px;
-}
-
-.btn_temperature_icon {
-  width: 30px;
-}
-
-.myChart{
+.todayChart {
   width: 1200px;
   height: 600px;
   margin: 0 auto;
+}
+
+.weeklyChart {
+  width: 1200px;
+  height: 600px;
+  margin: 0 auto;
+}
+
+.swiper {
+  margin: 0 50px;
+}
+
+.swiper-wrapper {
+  width: 100vw;
+  height: 100vh;
+}
+
+.swiper-button-prev,
+.swiper-button-next {
+  opacity: 0.5;
+  padding: 15px 5px;
+  border-radius: 20px;
+  color: black;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./dist/",
-    "sourceMap": true,
     "noImplicitAny": true,
     "module": "es6",
     "target": "es5",
-    "allowJs": true,
     "moduleResolution": "Node",
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const path = require("path");
 module.exports = {
   mode: "development",
   entry: "./src/index.ts",
-  devtool: "inline-source-map",
   devServer: {
     static: "./dist",
     hot: true,


### PR DESCRIPTION
2023.06.13

![image](https://github.com/f-lab-edu/check-weather-temperature/assets/73331052/e17d816f-21a3-4c07-bfea-893f13035304)

1. 조회 기간 확대
   - 금일까지 합하여 6일 조회 -> 8일 조회
2. 변수명 더 직관적이게 수정
   - dayAfterTomorrow -> after2days
3. 소스 정리

<hr/>

2023.06.12

![image](https://github.com/f-lab-edu/check-weather-temperature/assets/73331052/8bcbfa73-2179-4329-b5d4-0a31fc1e7e72)
![image](https://github.com/f-lab-edu/check-weather-temperature/assets/73331052/44eeebab-a5d3-41a0-920e-a5603d08572b)

1. 중기 API 적용으로 주간 날씨 완성
2. swiper 라이브러리 적용 (`<`, `>`버튼으로 페이지가 넘어가는 기능)
    - 그로 인해 `Go to Weekly`와 같은 버튼 삭제
3. webpack.config.js 및 tsconfig.js에 필요 없는 항목 삭제
4. '어제와 오늘 온도'를 '오늘과 내일 온도'로 수정
   - 관련 소스가 기입된 HTML, CSS, TS 파일 모두 수정
5. 그래프의 날짜 포맷 수정
   - 20230612 -> 06/12